### PR TITLE
[HRINFO-1129] hide Primary Tabs from visitors

### DIFF
--- a/config/block.block.common_design_subtheme_breadcrumbs.yml
+++ b/config/block.block.common_design_subtheme_breadcrumbs.yml
@@ -11,7 +11,7 @@ _core:
 id: common_design_subtheme_breadcrumbs
 theme: common_design_subtheme
 region: content
-weight: -5
+weight: -6
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/config/block.block.common_design_subtheme_local_tasks.yml
+++ b/config/block.block.common_design_subtheme_local_tasks.yml
@@ -2,6 +2,8 @@ uuid: c5c9acdd-386d-4c9c-a63b-0d2c851b0d08
 langcode: en
 status: true
 dependencies:
+  module:
+    - user
   theme:
     - common_design_subtheme
 _core:
@@ -9,14 +11,21 @@ _core:
 id: common_design_subtheme_local_tasks
 theme: common_design_subtheme
 region: content
-weight: -3
+weight: -4
 provider: null
 plugin: local_tasks_block
 settings:
   id: local_tasks_block
-  label: Tabs
+  label: 'Primary Tabs'
   label_display: '0'
   provider: core
   primary: true
-  secondary: true
-visibility: {  }
+  secondary: false
+visibility:
+  user_role:
+    id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
+    roles:
+      authenticated: authenticated

--- a/config/block.block.common_design_subtheme_page_title.yml
+++ b/config/block.block.common_design_subtheme_page_title.yml
@@ -9,7 +9,7 @@ _core:
 id: common_design_subtheme_page_title
 theme: common_design_subtheme
 region: content
-weight: -4
+weight: -5
 provider: null
 plugin: page_title_block
 settings:

--- a/config/block.block.tabs.yml
+++ b/config/block.block.tabs.yml
@@ -1,0 +1,20 @@
+uuid: 1715ca3a-9232-4ecc-9e7d-d78ab0bd4157
+langcode: en
+status: true
+dependencies:
+  theme:
+    - common_design_subtheme
+id: tabs
+theme: common_design_subtheme
+region: content
+weight: -3
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Secondary Tabs'
+  label_display: '0'
+  provider: core
+  primary: false
+  secondary: true
+visibility: {  }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -30,6 +30,8 @@ libraries-extend:
     - common_design_subtheme/cd-read-more
   common_design/cd-button:
     - common_design_subtheme/cd-button
+  common_design/cd-tabs:
+    - common_design_subtheme/cd-tabs
 
 # Custom namespace
 # https://www.drupal.org/docs/contributed-modules/components/understanding-twig-namespaces

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -13,3 +13,8 @@ cd-button:
   css:
     theme:
       components/cd-button/cd-button.css: {}
+
+cd-tabs:
+  css:
+    theme:
+      components/cd-tabs/cd-tabs.css: {}

--- a/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
@@ -1,0 +1,12 @@
+/**
+ * HR.info overrides for CD Tabs component.
+ */
+ul.tabs > li > a,
+ul.tabs > li > a.is-active {
+  color: var(--implementation-primary);
+}
+
+ul.tabs > li > a:focus {
+  outline: 3px solid var(--implementation-highlight);
+  background: #f1ecec;
+}


### PR DESCRIPTION
# HRINFO-1129

There are two sets of tabs for all users right now. The Editors probably need both sets for the foreseeable future, but anonymous visitors only had Home/View which were both the same URL, and it leads to the page you're already on. Safe to say they don't need those tabs cluttering up the top of their page.

While I was in there, I made the tabs use our HR.info colors.

With PR applied: `drush cim && drush cr`

<img width="1516" alt="Screen Shot 2022-03-11 at 13 54 41" src="https://user-images.githubusercontent.com/254753/157870410-bd5e7c98-6c32-4c23-addd-ab954b537fc2.png">

