### PR TITLE
[HRINFO-1133] emphasize Operation name within secondary tabs

### DIFF
--- a/config/block.block.common_design_subtheme_breadcrumbs.yml
+++ b/config/block.block.common_design_subtheme_breadcrumbs.yml
@@ -11,7 +11,7 @@ _core:
 id: common_design_subtheme_breadcrumbs
 theme: common_design_subtheme
 region: content
-weight: -6
+weight: -5
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/config/block.block.common_design_subtheme_local_tasks.yml
+++ b/config/block.block.common_design_subtheme_local_tasks.yml
@@ -11,7 +11,7 @@ _core:
 id: common_design_subtheme_local_tasks
 theme: common_design_subtheme
 region: content
-weight: -4
+weight: -6
 provider: null
 plugin: local_tasks_block
 settings:

--- a/config/block.block.common_design_subtheme_page_title.yml
+++ b/config/block.block.common_design_subtheme_page_title.yml
@@ -9,7 +9,7 @@ _core:
 id: common_design_subtheme_page_title
 theme: common_design_subtheme
 region: content
-weight: -5
+weight: -4
 provider: null
 plugin: page_title_block
 settings:

--- a/config/block.block.operation_tabs.yml
+++ b/config/block.block.operation_tabs.yml
@@ -1,10 +1,10 @@
-uuid: 1715ca3a-9232-4ecc-9e7d-d78ab0bd4157
+uuid: 4de02c18-c639-4ab1-bf99-1d538ebda4b6
 langcode: en
 status: true
 dependencies:
   theme:
     - common_design_subtheme
-id: tabs
+id: operation_tabs
 theme: common_design_subtheme
 region: content
 weight: -3
@@ -12,7 +12,7 @@ provider: null
 plugin: local_tasks_block
 settings:
   id: local_tasks_block
-  label: 'Secondary Tabs'
+  label: 'Operation Tabs'
   label_display: '0'
   provider: core
   primary: false

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -37,6 +37,8 @@ libraries-extend:
   common_design/cd-pagination:
     - common_design_subtheme/hri-pagination
 
+libraries-override:
+  common_design/cd-tabs: common_design_subtheme/cd-tabs
 
 # Custom namespace
 # https://www.drupal.org/docs/contributed-modules/components/understanding-twig-namespaces

--- a/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
@@ -3,7 +3,7 @@ ul.tabs {
   margin: 1rem 0 2rem;
   padding: 0;
   list-style: none;
-  border-bottom: 2px solid var(--cd-blue-grey);
+  border-bottom: 2px solid var(--implementation-light);
 }
 
 /* Clearfix */
@@ -28,9 +28,9 @@ ul.tabs > li > a {
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
-  color: var(--cd-ocha-blue);
+  color: var(--implementation-primary);
   border: 0 none;
-  border-bottom: 2px solid var(--cd-blue-grey);
+  border-bottom: 2px solid var(--implementation-light);
   border-radius: 0;
   background: none;
   font-weight: 700;
@@ -62,17 +62,17 @@ ul.tabs > li > a {
 
 ul.tabs > li > a.is-active,
 ul.tabs > li > a:hover {
-  color: var(--cd-ocha-blue);
+  color: var(--implementation-primary);
   border: 0 none !important;
-  border-bottom: 2px solid var(--cd-blue-grey) !important;
-  background-color: var(--cd-blue-grey);
+  border-bottom: 2px solid var(--implementation-light) !important;
+  background-color: var(--implementation-light);
 }
 
 ul.tabs > li > a.is-active {
-  background-color: var(--cd-grey--light);
+  background-color: var(--implementation-light);
 }
 
 ul.tabs > li > a:focus {
-  outline: 3px solid var(--cd-blue--bright);
-  background: var(--cd-blue-grey);
+  outline: 3px solid var(--implementation-highlight);
+  background: var(--implementation-light);
 }

--- a/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
@@ -1,27 +1,29 @@
 ul.tabs {
-  display: block;
+  --cd-tabs-border-width: 2px;
+
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.5rem;
   margin: 1rem 0 2rem;
   padding: 0;
   list-style: none;
-  border-bottom: 2px solid var(--implementation-light);
-}
-
-/* Clearfix */
-ul.tabs::after {
-  display: block;
-  visibility: hidden;
-  clear: both;
-  height: 0;
-  content: ".";
+  border-bottom: var(--cd-tabs-border-width) solid var(--implementation-light);
 }
 
 ul.tabs > li {
   display: block;
+  flex: 0 0 100%;
   margin: 0;
+  margin-bottom: calc(var(--cd-tabs-border-width) * -1);
+}
+
+@media (min-width: 576px) {
+  ul.tabs > li {
+    flex-basis: auto;
+  }
 }
 
 ul.tabs > li > a {
-  position: relative;
   display: block;
   margin: 0;
   padding: 0.25rem 1rem;
@@ -30,34 +32,10 @@ ul.tabs > li > a {
   text-transform: uppercase;
   color: var(--implementation-primary);
   border: 0 none;
-  border-bottom: 2px solid var(--implementation-light);
+  border-bottom: var(--cd-tabs-border-width) solid var(--implementation-light);
   border-radius: 0;
   background: none;
   font-weight: 700;
-}
-
-@media (min-width: 576px) {
-  ul.tabs > li {
-    position: relative;
-    /* Height of border bottom. */
-    margin-bottom: -2px;
-  }
-
-  [dir="ltr"] ul.tabs > li {
-    float: left;
-    margin-right: 0.5rem;
-  }
-
-  [dir="rtl"] ul.tabs > li {
-    float: right;
-    margin-left: 0.5rem;
-  }
-}
-
-@media (min-width: 768px) {
-  ul.tabs > li > a {
-    min-width: 7rem; /* 112px */
-  }
 }
 
 ul.tabs > li > a.is-active,

--- a/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
@@ -13,6 +13,7 @@ ul.tabs {
 ul.tabs > li {
   display: block;
   flex: 0 0 100%;
+  align-self: flex-end;
   margin: 0;
   margin-bottom: calc(var(--cd-tabs-border-width) * -1);
 }
@@ -53,4 +54,14 @@ ul.tabs > li > a.is-active {
 ul.tabs > li > a:focus {
   outline: 3px solid var(--implementation-highlight);
   background: var(--implementation-light);
+}
+
+/**
+ * Operation tabs visual treatment
+ */
+#block-operation-tabs ul.tabs > li:first-child > a {
+  text-transform: none;
+  color: inherit;
+  background-color: var(--implementation-light);
+  font-size: var(--cd-font-size--large);
 }

--- a/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
+++ b/html/themes/custom/common_design_subtheme/components/cd-tabs/cd-tabs.css
@@ -1,17 +1,78 @@
-/**
- * HR.info overrides for CD Tabs component.
- */
-ul.tabs > li > a,
+ul.tabs {
+  display: block;
+  margin: 1rem 0 2rem;
+  padding: 0;
+  list-style: none;
+  border-bottom: 2px solid var(--cd-blue-grey);
+}
+
+/* Clearfix */
+ul.tabs::after {
+  display: block;
+  visibility: hidden;
+  clear: both;
+  height: 0;
+  content: ".";
+}
+
+ul.tabs > li {
+  display: block;
+  margin: 0;
+}
+
+ul.tabs > li > a {
+  position: relative;
+  display: block;
+  margin: 0;
+  padding: 0.25rem 1rem;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  color: var(--cd-ocha-blue);
+  border: 0 none;
+  border-bottom: 2px solid var(--cd-blue-grey);
+  border-radius: 0;
+  background: none;
+  font-weight: 700;
+}
+
+@media (min-width: 576px) {
+  ul.tabs > li {
+    position: relative;
+    /* Height of border bottom. */
+    margin-bottom: -2px;
+  }
+
+  [dir="ltr"] ul.tabs > li {
+    float: left;
+    margin-right: 0.5rem;
+  }
+
+  [dir="rtl"] ul.tabs > li {
+    float: right;
+    margin-left: 0.5rem;
+  }
+}
+
+@media (min-width: 768px) {
+  ul.tabs > li > a {
+    min-width: 7rem; /* 112px */
+  }
+}
+
+ul.tabs > li > a.is-active,
+ul.tabs > li > a:hover {
+  color: var(--cd-ocha-blue);
+  border: 0 none !important;
+  border-bottom: 2px solid var(--cd-blue-grey) !important;
+  background-color: var(--cd-blue-grey);
+}
+
 ul.tabs > li > a.is-active {
-  color: var(--implementation-primary);
+  background-color: var(--cd-grey--light);
 }
 
 ul.tabs > li > a:focus {
-  outline: 3px solid var(--implementation-highlight);
-  background: var(--implementation-light);
-}
-
-ul.tabs > li > a:hover {
-  color: var(--implementation-primary);
-  background: var(--implementation-light);
+  outline: 3px solid var(--cd-blue--bright);
+  background: var(--cd-blue-grey);
 }


### PR DESCRIPTION
# HRINFO-1133

Builds upon the new labels from yesterday:

<img width="1290" alt="tabs with emphasized Operation name" src="https://user-images.githubusercontent.com/254753/158626001-8ca20422-3058-4ca0-962a-7c054123da58.png">

