### PR TITLE
[HRINFO-1135] visual cleanup of Offices tab

### DIFF
--- a/config/core.base_field_override.node.article.promote.yml
+++ b/config/core.base_field_override.node.article.promote.yml
@@ -14,7 +14,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: 1
+    value: 0
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/config/core.entity_view_display.node.article.operation_tab.yml
+++ b/config/core.entity_view_display.node.article.operation_tab.yml
@@ -1,0 +1,30 @@
+uuid: bc1212e4-b2f6-4e0e-8eed-630478974f67
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.operation_tab
+    - field.field.node.article.field_paragraphs
+    - node.type.article
+  module:
+    - layout_paragraphs
+    - user
+_core:
+  default_config_hash: b4RQ-Nfz-gOoG_jjftd_qDIz4lf_-OzlxoLHkRXjfrE
+id: node.article.operation_tab
+targetEntityType: node
+bundle: article
+mode: operation_tab
+content:
+  field_paragraphs:
+    type: layout_paragraphs
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  langcode: true
+  links: true

--- a/config/core.entity_view_mode.node.operation_tab.yml
+++ b/config/core.entity_view_mode.node.operation_tab.yml
@@ -1,0 +1,10 @@
+uuid: 608bc0d8-a725-4b60-81ad-fa887a8c9415
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.operation_tab
+label: 'Operation tab'
+targetEntityType: node
+cache: true

--- a/config/node.type.article.yml
+++ b/config/node.type.article.yml
@@ -1,7 +1,14 @@
 uuid: 5dfb8de0-7e4f-4be8-9911-14ee34d77eb8
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
 _core:
   default_config_hash: AeW1SEDgb1OTQACAWGhzvMknMYAJlcZu0jljfeU3oso
 name: Article
@@ -10,4 +17,4 @@ description: 'Use <em>articles</em> for time-sensitive content like news, press 
 help: ''
 new_revision: true
 preview_mode: 1
-display_submitted: true
+display_submitted: false

--- a/html/modules/custom/hr_paragraphs/src/Breadcrumb/GroupContentBreadcrumbBuilder.php
+++ b/html/modules/custom/hr_paragraphs/src/Breadcrumb/GroupContentBreadcrumbBuilder.php
@@ -27,6 +27,11 @@ class GroupContentBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
     $group_content_array = GroupContent::loadByEntity($node);
     $group_content = reset($group_content_array);
+
+    if (gettype($group_content) === 'boolean') {
+      return $group_content;
+    }
+
     $group = $group_content->getGroup();
 
     if (!$group) {

--- a/html/modules/custom/hr_paragraphs/src/Controller/ParagraphController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/ParagraphController.php
@@ -212,7 +212,7 @@ class ParagraphController extends ControllerBase {
     }
 
     $entity_type = 'node';
-    $view_mode = 'full';
+    $view_mode = 'operation_tab';
     $params = $link->getUrl()->getRouteParameters();
 
     $office_page = $this->entityTypeManager->getStorage($entity_type)->load($params[$entity_type]);

--- a/html/modules/custom/hr_paragraphs/src/Controller/ParagraphController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/ParagraphController.php
@@ -235,7 +235,7 @@ class ParagraphController extends ControllerBase {
     $link = $group->field_pages_page->first();
 
     $entity_type = 'node';
-    $view_mode = 'full';
+    $view_mode = 'operation_tab';
     $params = $link->getUrl()->getRouteParameters();
 
     $office_page = $this->entityTypeManager->getStorage($entity_type)->load($params[$entity_type]);

--- a/html/modules/custom/hr_paragraphs/templates/group-nodes.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/group-nodes.html.twig
@@ -1,8 +1,16 @@
+{#
+/**
+ * @file
+ * Default template for Operation Pages list.
+ *
+ * @see hr_paragraphs_preprocess_paragraph__group_pages()
+ */
+#}
 <div class="group-nodes block">
-  <h3>{{ 'Pages'|trans }}</h3>
-  <ul class="group-nodes--list">
+  <h2>{{ 'Pages'|t }}</h2>
+  <ul class="group-nodes__list">
     {% for node in nodes %}
-      <li class="group-nodes--node">
+      <li class="group-nodes__node">
         <a href="{{ node.link }}">{{ node.label }}</a>
       </li>
     {% endfor %}

--- a/html/themes/custom/common_design_subtheme/templates/field--paragraph--field-text--text-block.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/field--paragraph--field-text--text-block.html.twig
@@ -1,0 +1,54 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * @overrides html/themes/contrib/common_design/templates/field/field.html.twig
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{{ attach_library('common_design/cd-table') }}
+
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    label_display == 'inline' ? 'clearfix',
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes.addClass(classes, 'field__items') }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes.addClass(classes) }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+      <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/field--paragraph--field-title--text-block.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/field--paragraph--field-title--text-block.html.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * @overrides html/themes/contrib/common_design/templates/field/field.html.twig
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    label_display == 'inline' ? 'clearfix',
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% for item in items %}
+  <h2{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</h2>
+{% endfor %}

--- a/html/themes/custom/common_design_subtheme/templates/node--article--operation-tab.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/node--article--operation-tab.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * @overrides html/core/themes/stable/templates/content/node.html.twig
+ *
+ * @see template_preprocess_node()
+ *
+ */
+#}
+<article{{ attributes }}>
+  <div{{ content_attributes }}>
+    {{ content }}
+  </div>
+</article>


### PR DESCRIPTION
# HRINFO-1135

It's basically a new View Mode that we can use for template overrides on any content, along with other minor config/twig to hide bylines and titles.

The branch also includes the first fix I could find that restored my ability to view/edit Articles that display at their own URL such as `/node/14` (as opposed to displaying as a tab within an Operation at `/operations/OP/offices`)

<img width="1211" alt="operation-tab-view-mode" src="https://user-images.githubusercontent.com/254753/158999084-9426032b-d68f-4d4c-82bd-e8ed8ba46788.png">

