### PR TITLE
Table formatting of various Operation Tabs

### DIFF
--- a/html/modules/custom/hr_paragraphs/templates/hdx-dataset.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hdx-dataset.html.twig
@@ -2,8 +2,8 @@
   <thead>
     <tr>
       <th data-title="Dataset">{{ 'Dataset'|t }}</th>
-      <th data-title="Last updated">{{ 'Last updated'|t }}</th>
       <th data-title="Source">{{ 'Source'|t }}</th>
+      <th data-title="Last updated">{{ 'Last updated'|t }}</th>
     </tr>
   </thead>
   <tbody>
@@ -12,8 +12,8 @@
       <td data-title="Dataset">
         <a href="https://data.humdata.org/dataset/{{ row.id }}">{{ row.title }}</a>
       </td>
-      <td data-title="Last updated">{{ row.last_modified|date("d M Y") }} </td>
       <td data-title="Source">{{ row.source }}</td>
+      <td data-title="Last updated">{{ row.last_modified|date("d M Y") }} </td>
     </tr>
     {% endfor %}
   </tbody>

--- a/html/themes/custom/common_design_subtheme/templates/hdx-dataset.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hdx-dataset.html.twig
@@ -4,8 +4,8 @@
   <thead>
     <tr>
       <th data-title="Dataset" class="cd-table--name">{{ 'Dataset'|t }}</th>
-      <th data-title="Last updated" class="cd-table--name">{{ 'Last updated'|t }}</th>
       <th data-title="Source" class="cd-table--name">{{ 'Source'|t }}</th>
+      <th data-title="Last updated" class="cd-table--name">{{ 'Last updated'|t }}</th>
     </tr>
   </thead>
   <tbody>
@@ -14,8 +14,8 @@
       <td data-title="Dataset">
         <a href="https://data.humdata.org/dataset/{{ row.id }}">{{ row.title }}</a>
       </td>
-      <td data-title="Last updated">{{ row.last_modified|date("d M Y") }} </td>
       <td data-title="Source">{{ row.source }}</td>
+      <td data-title="Last updated">{{ row.last_modified|date("d M Y") }} </td>
     </tr>
     {% endfor %}
   </tbody>

--- a/html/themes/custom/common_design_subtheme/templates/layout/rw-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/layout/rw-river.html.twig
@@ -8,7 +8,7 @@
         <tr>
           <th class="cd-table--name" data-title="Name">{{ 'Name'|t }}</th>
           <th class="cd-table--name" data-title="Type">{{ 'Type'|t }}</th>
-          <th class="cd-table--name" data-title="Managed by">{{ 'Managed by'|t }}</th>
+          <th class="cd-table--name" data-title="Source">{{ 'Source'|t }}</th>
           <th class="cd-table--name" data-title="Last updated">{{ 'Last updated'|t }}</th>
           <th class="cd-table--name" data-title="Files">{{ 'Files'|t }}</th>
         </tr>
@@ -20,7 +20,7 @@
             <a href="{{ row.url }}">{{ row.title }}</a>
           </td>
           <td data-title="Type">{{ row.format }}</td>
-          <td data-title="Managed by">{{ row.sources }}</td>
+          <td data-title="Source">{{ row.sources }}</td>
           <td data-title="Last updated">{{ row.date_changed|date("d M Y") }} </td>
           <td data-title="Files">
             {% if row.files|length > 0 %}


### PR DESCRIPTION
# HRINFO-1150, HRINFO-1158

The tables now place `Last updated` as far to the right as possible (sometimes there is a "Files" column which is at the end).

We swapped the words "Managed by" to be "Source" in all tables.