### PR TITLE
[HRINFO-1135] restore contextual links for roles that need them

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/node--article--operation-tab.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/node--article--operation-tab.html.twig
@@ -10,6 +10,8 @@
  */
 #}
 <article{{ attributes }}>
+  {{ title_suffix }}
+
   <div{{ content_attributes }}>
     {{ content }}
   </div>


### PR DESCRIPTION
# HRINFO-1135

TIL that contextual links get printed inside the `title_suffix` variable on node templates.