### PR TITLE
[HRINFO-1140] Clean up the text blocks

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -88,3 +88,8 @@ hri-table:
       components/hri-table/hri-table.css: {}
   dependencies:
     - common_design/cd-table
+
+hri-text-block:
+  css:
+    theme:
+      components/hri-text-block/hri-text-block.css: {}

--- a/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
@@ -12,3 +12,17 @@
   height: 0;
   content: ".";
 }
+
+/**
+ * Because core's align-left/align-right classes do not look for the HTML dir
+ * attribute, we use the older left/right margin directions and intentionally
+ * avoid looking at the HTML's dir attribute.
+ *
+ * @see html/core/modules/system/css/components/align.module.css
+ */
+.paragraph--type--text-block .align-left {
+  margin-right: 1rem;
+}
+.paragraph--type--text-block .align-right {
+  margin-left: 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
@@ -1,0 +1,14 @@
+/**
+ * HR.info Text Block paragraph type.
+ */
+
+/**
+ * Our WYSIWYG editor image float styles need to be cleared
+ */
+.paragraph--type--text-block::after {
+  display: block;
+  visibility: hidden;
+  clear: both;
+  height: 0;
+  content: ".";
+}

--- a/html/themes/custom/common_design_subtheme/templates/field--paragraph--field-text--text-block.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/field--paragraph--field-text--text-block.html.twig
@@ -9,6 +9,7 @@
  */
 #}
 {{ attach_library('common_design/cd-table') }}
+{{ attach_library('common_design_subtheme/hri-text-block') }}
 
 {%
   set classes = [

--- a/html/themes/custom/hri_admin/css/admin.css
+++ b/html/themes/custom/hri_admin/css/admin.css
@@ -59,3 +59,10 @@
   padding: 0;
   padding-inline-end: 1rem;
 }
+
+.paragraph--type--text-block .align-left {
+  margin-right: 1rem;
+}
+.paragraph--type--text-block .align-right {
+  margin-left: 1rem;
+}


### PR DESCRIPTION
# HRINFO-1140

Fixes problems with floated images:

- Paragraphs that follow weren't clearing automatically.
- Text that flowed next to image had no margin.
- Admin theme tweaks so Editors see the same basic thing as the published content.