### PR TITLE
[HRINFO-1195] explicitly query formats considered to be Reports

### DIFF
--- a/html/modules/custom/hr_paragraphs/src/Controller/ReliefwebController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/ReliefwebController.php
@@ -435,9 +435,8 @@ class ReliefwebController extends ControllerBase {
         case 'reports':
           $conditions['reports'] = [
             'field' => 'format.id',
-            'value' => [12, 12570, 38974],
+            'value' => [3, 4, 5, 6, 7, 8, 9, 10, 11],
             'operator' => 'OR',
-            'negate' => TRUE,
           ];
           break;
 


### PR DESCRIPTION
Negating the maps/infographics formats seemed to still provide only maps/infographics. We could probably investigate the `negate` parameter but in the mean time I removed it and provided an explicit allow-list of format IDs.

Refs: HRINFO-1195