### PR TITLE
[HRINFO-1189] strip tags before displaying description

### DIFF
--- a/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rss-feed.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rss-feed.html.twig
@@ -12,11 +12,11 @@
         {% if item.description|length > 0 %}
           {% if options.display_each_item_full %}
             <div class="external-feed--item-description--full">
-              {{ item.description }}
+              {{ item.description|striptags|raw }}
             </div>
           {% else %}
             <div class="external-feed--item-description--teaser">
-              {{ item.description|slice(0, 200)|raw }}
+              {{ item.description|slice(0, 200)|striptags|raw }}
             </div>
           {% endif %}
         {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rss-feed.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rss-feed.html.twig
@@ -16,11 +16,11 @@
         {% if item.description|length > 0 %}
           {% if options.display_each_item_full %}
             <div class="external-feed--item-description--full">
-              {{ item.description }}
+              {{ item.description|striptags|raw }}
             </div>
           {% else %}
             <div class="external-feed--item-description--teaser">
-              {{ item.description|slice(0, 200)|raw }}
+              {{ item.description|slice(0, 200)|striptags|raw }}
             </div>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
# HRINFO-1189

The template intentionally displays the content with `raw` filter, because it comes from RW with encoded characters such as `&#39;` for apostrophes. However there's no reason to skip `striptags` before the `raw` filter. Easy fix.