### PR TITLE
[HRINFO-1189] strip tags before truncating RSS description

### DIFF
--- a/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rss-feed.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rss-feed.html.twig
@@ -16,7 +16,7 @@
             </div>
           {% else %}
             <div class="external-feed--item-description--teaser">
-              {{ item.description|slice(0, 200)|striptags|raw }}
+              {{ item.description|striptags|slice(0, 200)|raw }}
             </div>
           {% endif %}
         {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rss-feed.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rss-feed.html.twig
@@ -20,7 +20,7 @@
             </div>
           {% else %}
             <div class="external-feed--item-description--teaser">
-              {{ item.description|slice(0, 200)|striptags|raw }}
+              {{ item.description|striptags|slice(0, 200)|raw }}
             </div>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
# HRINFO-1189

Switches the order of operations to avoid outputting broken tags that might result from truncation.