### PR TITLE
[HRINFO-1207] apply WYSIWYG clearfix to all instances of field_text

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
@@ -1,11 +1,12 @@
 /**
- * HR.info Text Block paragraph type.
+ * HR.info customizations to ALL instances of field_text. It appears as a
+ * universal description field on most Paragraph types.
  */
 
 /**
  * Our WYSIWYG editor image float styles need to be cleared
  */
-.paragraph--type--text-block::after {
+.field--name-field-text::after {
   display: block;
   visibility: hidden;
   clear: both;
@@ -20,9 +21,9 @@
  *
  * @see html/core/modules/system/css/components/align.module.css
  */
-.paragraph--type--text-block .align-left {
+.field--name-field-text .align-left {
   margin-right: 1rem;
 }
-.paragraph--type--text-block .align-right {
+.field--name-field-text .align-right {
   margin-left: 1rem;
 }


### PR DESCRIPTION
# HRINFO-1207

The styles originally applied to the Text Block paragraph type only. PR applies the styles to all `field_text` instances, which are used as a universal Description field on most Paragraph types.